### PR TITLE
1.0.1 move script location

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ logger.newlevel("this shows your new level")
 ### class attributes
 These values affect every instance of CustomLogger
 
-`add_script_location`: bool will add the file and line number of the file where log was called
-    * In PyCharm if you install the Awesome Console plugin it will make it a hyperlink that will navigate you to
-      the code where log was called
-
 `logging_disabled`: bool enables or disables ALL Logging from CustomLogger
 
 `default_logging_level`: int the logging level assigned to each logger by default
@@ -114,7 +110,35 @@ from custom_loggers import ColoredFormatter
 ```
 For all things colored
 
-The primary thing you need to know here is:
+There are 3 Things to note here:
+### 1:
+Color text doesn't work on all terminals primarily you will find issues in Windows CMD and Powershell.
+By default colors will not attempt to print on Windows you can override this by setting WINDOWS_OVERRIDE=True
+```python
+from custom_loggers import ColoredFormatter
+ColoredFormatter.WINDOWS_OVERRIDE = True
+```
+There are tools to add ANSI support to Windows terminals in which case colors *may work*.
+
+### 2:
+ColoredFormatter adds three additional formatting options for your logging format.
+
+All three are associated with getting the script that calls one of a CustomLogger.log methods. It grabs the script 
+location and assigns this to these formatting names. These are similar to 'filepath', 'filename', 'lineno' but could be 
+different. These will be more accurate for CustomLoggers
+`scriptpath` : the full path to the script that called log
+`scriptname` : the file name of the script
+`scriptline` : the line number of the script
+
+```python
+from custom_loggers import CustomLogger
+
+CustomLogger.default_colored_format = '%(asctime)s [%(scriptname)s, %(scriptline)s] %(levelname)-8s %(name)s: %(message)s'
+
+```
+
+### 3:
+Assigning Colors to level is done like below:
 ```python
 from custom_loggers import ColoredFormatter
 from custom_loggers import Colors

--- a/README.md
+++ b/README.md
@@ -111,30 +111,42 @@ from custom_loggers import ColoredFormatter
 For all things colored
 
 There are 3 Things to note here:
-### 1:
+### 1: Windows
 Color text doesn't work on all terminals primarily you will find issues in Windows CMD and Powershell.
-By default colors will not attempt to print on Windows you can override this by setting WINDOWS_OVERRIDE=True
+By default, colors will not attempt to print on Windows you can override this by setting WINDOWS_OVERRIDE=True
 ```python
 from custom_loggers import ColoredFormatter
 ColoredFormatter.WINDOWS_OVERRIDE = True
 ```
 There are tools to add ANSI support to Windows terminals in which case colors *may work*.
 
-### 2:
+### 2: Additional Formatting
 ColoredFormatter adds three additional formatting options for your logging format.
 
 All three are associated with getting the script that calls one of a CustomLogger.log methods. It grabs the script 
 location and assigns this to these formatting names. These are similar to 'filepath', 'filename', 'lineno' but could be 
-different. These will be more accurate for CustomLoggers
+different. These will be more accurate for CustomLoggers. 
 `scriptpath` : the full path to the script that called log
 `scriptname` : the file name of the script
 `scriptline` : the line number of the script
 
+As a side note if you use a plugin for your IDE you may be able to get the filename and line number to have be a 
+hyperlink in the IDE's terminal. For example in PyCharm if you use the below format {scriptname}, line {scriptline}
+and install the Awesome Console plugin. each of those references will take you directly to the script.
+
 ```python
 from custom_loggers import CustomLogger
 
-CustomLogger.default_colored_format = '%(asctime)s [%(scriptname)s, %(scriptline)s] %(levelname)-8s %(name)s: %(message)s'
-
+CustomLogger.default_colored_format = '%(asctime)s [%(scriptname)s, line %(scriptline)-3s] %(levelname)-8s %(name)s: %(message)s'
+# Will output like this
+# 21-04-29 08:39 [main.py, line 15 ] INFO     channel_tester: channel test on
+# 21-04-29 08:39 [main.py, line 16 ] INFO     channel_tester2: channel test on
+# 21-04-29 08:39 [main.py, line 23 ] TRACE    testLogger: just checking
+# 21-04-29 08:39 [main.py, line 24 ] ERROR    testLogger: Hello
+# 21-04-29 08:39 [main.py, line 25 ] INFO     testLogger: Hello
+# 21-04-29 08:39 [main.py, line 26 ] DEBUG    testLogger: Hello
+# 21-04-29 08:39 [main.py, line 27 ] WARNING  testLogger: Hello
+# 21-04-29 08:39 [main.py, line 28 ] WARNING  testLogger: Hello
 ```
 
 ### 3:
@@ -152,6 +164,11 @@ the log line which starts the color print)
 ## Colors
 ```python
 from custom_loggers import Colors
+```
+or directly with the class you are looking for
+```python
+from custom_loggers import ForeGroundColors, BackGroundColors, Foreground255, Background255 
+from custom_loggers import print_16_colors,print_255_colors
 ```
 
 Colors is an internal module for getting and combining colors and font styles.
@@ -189,6 +206,6 @@ Colors.print_255_colors()
 ```
 
 #### Color Printout
-![Assets/colors_pic.png](Assets/colors_pic.png)
+![color_printout](https://github.com/astromness/custom_loggers/blob/main/Assets/colors_pic.png?raw=true)
 
 

--- a/custom_loggers/ColoredFormatter.py
+++ b/custom_loggers/ColoredFormatter.py
@@ -2,6 +2,8 @@ import logging
 import platform
 from custom_loggers.Colors import Foreground255,SequenceName,FontStyles
 from typing import Union
+import inspect
+from pathlib import Path
 
 
 class ColoredFormatter(logging.Formatter):
@@ -24,6 +26,7 @@ class ColoredFormatter(logging.Formatter):
         'ERROR': Foreground255(196),
         'TRACE': Foreground255(14)
     }
+    use_script_location=False
 
     @classmethod
     def assign_level_color(cls, levelname: str, color: Union[str, SequenceName]) -> None:
@@ -54,7 +57,36 @@ class ColoredFormatter(logging.Formatter):
         :return: fully formated message
         """
         levelname = record.levelname
-        s = super().format(record)
+
+        def get_instance_from_frame(fr):
+            import inspect
+            insp_args, _, _, value_dict = inspect.getargvalues(fr)
+            # we check the first parameter for the frame function is
+            # named 'self' this 98% means it's a class
+            if len(insp_args) and insp_args[0] == 'self':
+                instance = value_dict.get('self', None)
+                return instance
+            return None
+
+        frame = inspect.currentframe()
+        while True:
+            from logging import Logger
+            instance = get_instance_from_frame(frame)
+            if Path(frame.f_code.co_filename).name=="__init__.py":
+                pass
+            elif not isinstance(instance,ColoredFormatter) and not isinstance(instance,Logger):
+                break
+            frame = frame.f_back
+
+        func = frame.f_code
+
+        script_path=Path(func.co_filename)
+        record.scriptpath=str(script_path)
+        record.scriptname=script_path.name
+        record.scriptline=frame.f_lineno
+
+        s=super().format(record)
+
         if self.use_color and (not platform.system() == 'Windows' or ColoredFormatter.WINDOWS_OVERRIDE):
             if levelname in ColoredFormatter._COLORS_ASSIGNMENTS.keys():
                 return ColoredFormatter._COLORS_ASSIGNMENTS[levelname] + s + FontStyles.RESET

--- a/custom_loggers/CustomLogger.py
+++ b/custom_loggers/CustomLogger.py
@@ -44,7 +44,7 @@ class CustomLogger(logging.Logger):
     use_global_log_level_default: bool = False
     inclusive: bool = True
     default_formatter: logging.Formatter = ColoredFormatter
-    default_colored_format: str = '%(asctime)s [%(scriptname)s, %(scriptline)s] %(levelname)-8s %(name)s: %(message)s'
+    default_colored_format: str = '%(asctime)s [%(scriptname)s, line %(scriptline)-3s] %(levelname)-8s %(name)s: %(message)s'
     default_asctime_format: str = "%y-%m-%d %H:%M"
 
     _levels = dict(

--- a/custom_loggers/CustomLogger.py
+++ b/custom_loggers/CustomLogger.py
@@ -38,15 +38,14 @@ class CustomLogger(logging.Logger):
     default_colored_format:str the format string that the formatter will use
     default_asctime_format:str the asctime format the formatter will use
     """
-    add_script_location: bool = False
     logging_disabled: bool = False
     default_logging_level: int = 0
     global_log_level: int = 0
     use_global_log_level_default: bool = False
     inclusive: bool = True
     default_formatter: logging.Formatter = ColoredFormatter
-    default_colored_format: str = '%(asctime)s %(levelname)-8s %(name)s: %(message)s'
-    default_asctime_format: str = "%Y-%m-%d %H:%M:%S"
+    default_colored_format: str = '%(asctime)s [%(scriptname)s, %(scriptline)s] %(levelname)-8s %(name)s: %(message)s'
+    default_asctime_format: str = "%y-%m-%d %H:%M"
 
     _levels = dict(
         CRITICAL=50,
@@ -257,49 +256,3 @@ class CustomLogger(logging.Logger):
             level = self.check_level(level)
 
         return super().log(level, msg, *args, **kwargs)
-
-    def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False, stacklevel=1):
-        """
-        Used to add the script location to the super implementation, when add_class_from_frame is set to True
-        It will add it to the beginning of msg
-
-        :param level:
-        :param msg:
-        :param args:
-        :param exc_info:
-        :param extra:
-        :param stack_info:
-        :param stacklevel:
-        :return:
-        """
-
-        def get_class_from_frame(fr):
-            import inspect
-            insp_args, _, _, value_dict = inspect.getargvalues(fr)
-            # we check the first parameter for the frame function is
-            # named 'self'
-            if len(insp_args) and insp_args[0] == 'self':
-                # in that case, 'self' will be referenced in value_dict
-                instance = value_dict.get('self', None)
-                if instance:
-                    # return its class
-                    return getattr(instance, '__class__', None)
-                instance = value_dict.get('cls', None)
-                if instance:
-                    return instance
-            # return None otherwise
-            return None
-
-        if self.__class__.add_script_location:
-            frame = inspect.currentframe()
-            while True:
-                class_type = get_class_from_frame(frame)
-                if class_type != self.__class__:
-                    break
-                frame = frame.f_back
-
-            func = frame.f_code
-            msg = f"[{Path(func.co_filename).name}, line {str(frame.f_lineno).ljust(4)}] " + msg
-
-        super()._log(level, msg, args, exc_info, extra, stack_info, stacklevel)
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
-description-file = README.md
+long_description = README.md
+long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,28 @@
 from distutils.core import setup
 from pathlib import Path
-parent=Path(__file__).parent
-readme=parent/"README.md"
-with open(str(readme)) as f:
-  long_description=f.read()
+
+parent = Path(__file__).parent
+readme = parent / "README.md"
+with open(str(readme), encoding='utf-8',mode='r') as f:
+    long_description = f.read()
 
 setup(
-  name = 'custom_loggers',
-  packages = ['custom_loggers'],
-  version = '1.0.0',
-  license='MIT',
-  description = 'A Custom Logger Class for creating colored, adding level, other misc features',
-  long_description=long_description,
-  long_description_content_type="text/markdown",
-  author = 'Austin Stromness',
-  author_email = 'stromnessdevelopment@gmail.com',
-  url = 'https://github.com/astromness/custom_loggers',
-  download_url = 'https://github.com/astromness/custom_loggers/archive/refs/tags/1.0.0.tar.gz',
-  keywords = ['logging', 'colored', 'loglevel', 'console', 'custom'],
-  classifiers=[
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'Topic :: Software Development',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-  ],
+    name='custom_loggers',
+    packages=['custom_loggers'],
+    version='1.0.0',
+    license='MIT',
+    description='A Custom Logger Class for creating colored, adding level, other misc features',
+    author='Austin Stromness',
+    author_email='stromnessdevelopment@gmail.com',
+    url='https://github.com/astromness/custom_loggers',
+    download_url='https://github.com/astromness/custom_loggers/archive/refs/tags/1.0.0.tar.gz',
+    keywords=['logging', 'colored', 'loglevel', 'console', 'custom'],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+    ],
 )


### PR DESCRIPTION
Script location was located in CustomLog but really should be inside of ColoredFormatter. Which is now is.

ChangeList
Moved the frame logic to Colored Formatter
During formatting of the log record we use the first frame that's not inside of logging or custom_loggers libraries.
Using that frame we add scriptpath, scriptname, scriptline to the log recrod allowing for formatting using traditional logging methods.
Updaed README.md
